### PR TITLE
Error with prefix different of "$"

### DIFF
--- a/modules/addons/google_tag_manager/hooks.php
+++ b/modules/addons/google_tag_manager/hooks.php
@@ -99,12 +99,7 @@ add_hook('ClientAreaFooterOutput', 1, function($vars) {
   $currencyCode = $vars['activeCurrency']['code'];
   $lang = $vars['activeLocale']['languageCode'];
 
-  $currencyPrefix = '$'; //default, get live currency prefix below
-  foreach ( $vars['currencies'] as $currency ){
-    if ($currency['code'] === $currencyCode){
-      $currencyPrefix = $currency['prefix']; 
-    }
-  }
+  $currencyPrefix = $vars['WHMCSCurrency']['prefix']; 
   
   //if ( $_REQUEST['debug'] ) var_dump($vars['activeCurrency']['code']); ///DEBUG
   

--- a/modules/addons/google_tag_manager/hooks.php
+++ b/modules/addons/google_tag_manager/hooks.php
@@ -228,7 +228,7 @@ add_hook('ShoppingCartCheckoutCompletePage', 1, function($vars) {
   
   $currencyCode = $order['currencysuffix'];
 
-  $currencyPrefix =  $currencyPrefix = $vars['WHMCSCurrency']['prefix'];
+  $currencyPrefix = $order['currencyprefix'];
 	
   //if ( $_REQUEST['debug'] ) var_dump($order); ///DEBUG
   

--- a/modules/addons/google_tag_manager/hooks.php
+++ b/modules/addons/google_tag_manager/hooks.php
@@ -228,15 +228,8 @@ add_hook('ShoppingCartCheckoutCompletePage', 1, function($vars) {
   
   $currencyCode = $order['currencysuffix'];
 
-  $currencyPrefix = '$'; //default, get live currency prefix below
-  if (!is_null($vars['currencies'])){
-    foreach ( $vars['currencies'] as $currency ){
-      if ($currency['code'] === $currencyCode){
-        $currencyPrefix = $currency['prefix']; 
-      }
-    }
-  } 
-  
+  $currencyPrefix =  $currencyPrefix = $vars['WHMCSCurrency']['prefix'];
+	
   //if ( $_REQUEST['debug'] ) var_dump($order); ///DEBUG
   
   $itemsArray = array();


### PR DESCRIPTION
Using the "$vars['WHMCSCurrency']['prefix']" because is the actual order currency current, even if has other currencies configured. 

If you have only one currency, the page "cart.php?a=checkout" doesn't have the variable “currencies”. And the replacement doesn't work as expect if the currency prefix is different from "$".

For example, if you are using BRL. This is the output:

`{
  event: "begin_checkout",
  gtm: {uniqueEventId: 2, start: 1692734253256},
  ecommerce: {
    items: [
      {
        name: "Hospedagem Pessoal",
        id: 11,
        price: "R138.00",
        category: "Hospedagem de Site",
        quantity: 1
      }
    ]
  },
  eventAction: "checkout"
}
`

**The variable currency is not fond, and "R$”" is replaced with "$", so you get "price: "R138.00"" like the example.**

I think the check is no longer necessary:

`$currencyPrefix = $vars['WHMCSCurrency']['prefix']; //default, get live currency prefix below
  foreach ( $vars['currencies'] as $currency ){
    if ($currency['code'] === $currencyCode){
      $currencyPrefix = $currency['prefix']; 
    }
  }`
