### PR TITLE
Updated the ecommerce and sign up events. Updated the README file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ List of event tag names actively used:
 2. Add to Cart Event. Event Name: add_to_cart
 3. Begin Checkout Event. Event Name: begin_checkout
 4. Purchase Event. Event Name: purchase
+5. Sign Up Event. Event Name: sign_up
 
 The "Event Name" values will match with the HTML/JS markup this module generates, and enabling the Ecommerce data via Data Layer will ensure it captures the ecommerce data within that markup. This data will automatically fill out your Analytics report under Monetization > Ecommerce purchases.
 


### PR DESCRIPTION
This pull request does the following:
1. Added currency code to Ecommerce events
2. Updated the **sign_up** event to add additional fields / info - #7 
3. Added an **additional sign_up** event to the ClientAreaPageRegister hook - #7 
4. Updated the README file to include the sign_up event

### sign_up event on ClientAreaPageRegister hook
Here is some information on this additional sign_up event:
1. For some reason the ClientAreaRegister hook doesn't trigger on successful registration. At least it didn't on the WHMCS installation I worked on.
2. Using the ClientAreaPageRegister hook allows us to add JavaScript to the registration page to then implement the needed logic to capture the newly registered info & billing address data and add it to the datalayer. - https://developers.whmcs.com/hooks-reference/client-area-interface/#clientareapageregister
3. Additionally made sure that should reCAPTCHA be enabled, that the registration form is submitted with the reCAPTCHA data.