### PR TITLE
Security & privacy fixes + opt-in Consent Mode v2 + CONTRIBUTORS.md

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,27 @@
+# Contributors
+
+This module is built and maintained by the people listed below. Pull requests
+that improve the module, fix bugs, or add features are welcome: see the
+README for guidance.
+
+## Maintainer
+
+- **[Websavers Inc.](https://websavers.ca/)**: original author and project
+  owner. Canadian web hosting company. Releases this module free of charge
+  under GPLv3, without warranty or support obligation.
+
+## Contributors
+
+A non-exhaustive list of organisations and individuals who have contributed
+code, security reports, or documentation. Listed in chronological order of
+their first contribution.
+
+- **[RareCloud.io](https://rarecloud.io/)**: security and privacy review, XSS
+  hardening for the GTM container ID, removal of PII from the sign_up
+  dataLayer event to comply with Google Analytics' Terms of Service and the
+  GDPR data minimisation principle, and an opt-in Google Consent Mode v2
+  bootstrap for ePrivacy/EU compliance. European cloud hosting, VPS, and
+  proxy provider.
+
+For the full list of individual code authors, see the project's git history
+or [GitHub Contributors graph](https://github.com/websavers/WHMCS-Google-Tag-Manager/graphs/contributors).

--- a/modules/addons/google_tag_manager/google_tag_manager.php
+++ b/modules/addons/google_tag_manager/google_tag_manager.php
@@ -58,7 +58,7 @@ function google_tag_manager_config(){
         'description' => 'Automatically includes the GTM embed codes and provides the necessary JavaScript dataLayer for eCommerce events',
         'author' => 'Websavers Inc.',
         'language' => 'english',
-        'version' => '3.1',
+        'version' => '3.2',
         'fields' => [
             'gtm-container-id' => [
                 'FriendlyName' => 'GTM Container ID',
@@ -72,6 +72,12 @@ function google_tag_manager_config(){
                 'Type' => 'yesno',
                 'Default' => 'yes',
                 'Description' => 'Disable this if you will be using Google Tag Manager to create your events and DataLayer variables',
+            ],
+            'gtm-enable-consent-mode' => [
+                'FriendlyName' => 'Enable Google Consent Mode v2',
+                'Type' => 'yesno',
+                'Default' => 'no',
+                'Description' => 'Inject a Consent Mode v2 default-denied bootstrap before GTM loads. Required if your client area serves visitors in the EU/EEA/UK and you load any Google tags (GA4, Google Ads, etc.). When enabled, your cookie banner (or external CMP) is responsible for calling gtag(\'consent\', \'update\', { ... }) once the visitor accepts. Leave disabled if you are not using a cookie banner, or if your CMP already injects its own consent bootstrap before this module runs.',
             ],
         ]
     ];

--- a/modules/addons/google_tag_manager/hooks.php
+++ b/modules/addons/google_tag_manager/hooks.php
@@ -55,11 +55,28 @@ function gtm_ga_module_in_use(){
   return ($ga_is_active && !empty($ga_site_tag))? true:false;
 }
 
+/**
+ * Validate and sanitize the GTM container ID before injecting it into HTML/JS.
+ *
+ * Google Tag Manager container IDs follow the format `GTM-XXXXXXX` where the
+ * suffix is alphanumeric (uppercase). Anything outside that pattern is either
+ * a typo or an attempted injection, so we reject it. This stops a malicious
+ * (or compromised) admin from using the settings field as an XSS vector that
+ * would execute on every Client Area page load.
+ *
+ * Returns the validated ID, or an empty string if invalid.
+ */
+function gtm_safe_container_id($raw){
+  if (empty($raw)) return '';
+  $raw = trim($raw);
+  return preg_match('/^GTM-[A-Z0-9]+$/', $raw) ? $raw : '';
+}
+
 /** The following two hooks output the code required for GTM to function **/
 
 add_hook('ClientAreaHeadOutput', 1, function($vars) {
-  
-  $container_id = gtm_get_module_settings('gtm-container-id');
+
+  $container_id = gtm_safe_container_id(gtm_get_module_settings('gtm-container-id'));
 
   if (!empty($container_id)):
     return "<!-- Google Tag Manager -->
@@ -76,7 +93,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
 add_hook('ClientAreaHeaderOutput', 1, function($vars) {
 
-  $container_id = gtm_get_module_settings('gtm-container-id');
+  $container_id = gtm_safe_container_id(gtm_get_module_settings('gtm-container-id'));
   if (!empty($container_id)):
     return "<!-- Google Tag Manager (noscript) -->
 <noscript><iframe src='https://www.googletagmanager.com/ns.html?id=$container_id'

--- a/modules/addons/google_tag_manager/hooks.php
+++ b/modules/addons/google_tag_manager/hooks.php
@@ -72,7 +72,50 @@ function gtm_safe_container_id($raw){
   return preg_match('/^GTM-[A-Z0-9]+$/', $raw) ? $raw : '';
 }
 
-/** The following two hooks output the code required for GTM to function **/
+/** The following hooks output the code required for GTM to function **/
+
+/**
+ * Optional: inject Google Consent Mode v2 default-denied bootstrap BEFORE the
+ * GTM loader runs. When enabled, every Google tag GTM ships sees the correct
+ * consent state from the very first dataLayer event. Without this, tags would
+ * fire in their default (granted) mode until a cookie banner has a chance to
+ * call gtag('consent', 'update', ...), which on a fast-loading page can mean
+ * one or more page_views are recorded before consent is captured.
+ *
+ * Priority is 0 so this hook runs before the GTM loader (priority 1) registered
+ * below. WHMCS executes hooks of the same event in ascending priority order.
+ *
+ * The cookie banner (or external CMP) is responsible for calling
+ * gtag('consent', 'update', { ... }) on accept; this hook only sets the
+ * default state.
+ */
+add_hook('ClientAreaHeadOutput', 0, function($vars) {
+
+  if ( gtm_get_module_settings('gtm-enable-consent-mode') !== 'on' ) return '';
+  $container_id = gtm_safe_container_id(gtm_get_module_settings('gtm-container-id'));
+  if (empty($container_id)) return '';
+
+  return "<!-- Google Consent Mode v2 default (RareCloud / WHMCS-GTM module) -->
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+window.gtag = gtag;
+gtag('consent', 'default', {
+  'ad_storage': 'denied',
+  'ad_user_data': 'denied',
+  'ad_personalization': 'denied',
+  'analytics_storage': 'denied',
+  'functionality_storage': 'denied',
+  'personalization_storage': 'denied',
+  'security_storage': 'granted',
+  'wait_for_update': 500
+});
+gtag('set', 'url_passthrough', true);
+gtag('set', 'ads_data_redaction', true);
+</script>
+<!-- End Google Consent Mode v2 default -->";
+
+});
 
 add_hook('ClientAreaHeadOutput', 1, function($vars) {
 

--- a/modules/addons/google_tag_manager/hooks.php
+++ b/modules/addons/google_tag_manager/hooks.php
@@ -296,72 +296,53 @@ add_hook('ShoppingCartCheckoutCompletePage', 1, function($vars) {
 
 
 add_hook('ClientAreaPageRegister', 1, function($vars) {
-    
+
 	if ( gtm_get_module_settings('gtm-enable-datalayer') == 'off' ) return '';
 
 	add_hook('ClientAreaFooterOutput', 1, function($vars) {
 
-		return '
-		<script id="GTM_DataLayer">
-		
-			document.querySelectorAll("#inputNewPassword1, #inputNewPassword2, #inputEmail").forEach(field => {
-				field.setAttribute("required", "");
-			});
-			
-			document.querySelector("form#frmCheckout input[type=\"submit\"]").onclick = function(e) {
-				e.preventDefault();
+		// We push a privacy-minimal sign_up event: just `event` + `method`.
+		// We deliberately do NOT include first_name, last_name, email, phone or
+		// address fields here. Google Analytics' Terms of Service explicitly
+		// forbid sending personally identifiable information (PII) to GA, and
+		// under GDPR the principle of data minimisation requires that we only
+		// transfer what is strictly necessary for the analytics purpose. A
+		// sign_up conversion only needs to know that a sign-up happened, not
+		// who signed up. If you need user-level conversion attribution for
+		// Google Ads, configure Google Ads Enhanced Conversions in the GTM UI;
+		// that pathway hashes the PII (SHA-256) before sending and uses a
+		// separate, audited transfer mechanism.
+		//
+		// We also use a "submit" listener instead of hijacking the submit
+		// button click + e.preventDefault() + register_form.submit(). The old
+		// approach broke client-side form validation and blocked any other
+		// JavaScript that listened to the form's normal submit lifecycle.
+		return <<<HTML
+<script id="GTM_DataLayer">
+(function() {
+  var form = document.getElementById("frmCheckout");
+  if (!form) return;
 
-				const register_form 		= document.getElementById("frmCheckout");
-				const inputCountry			= document.querySelector("#inputCountry");
-				let first_name              = document.querySelector("#inputFirstName").value;
-				let last_name               = document.querySelector("#inputLastName").value;
-				let email_address           = document.querySelector("#inputEmail").value;
-				let phone_number            = document.querySelector("#inputPhone").value.replace(/\\s+/g, "");
-				//let phone_country_code      = document.querySelector(".selected-dial-code").innerHTML;
-				let city                    = document.querySelector("#inputCity").value;
-				let state                   = document.querySelector("#stateinput").value;
-				let country                 = inputCountry.options[inputCountry.selectedIndex].text;
-				let postal_code             = document.querySelector("#inputPostcode").value;
-				let street_address          = document.querySelector("#inputAddress1").value;
+  // Preserve the previous client-side UX patch: WHMCS' default
+  // clientregister.tpl does not mark email/password as `required`, so empty
+  // submissions silently round-trip to the server before erroring. Add the
+  // attribute client-side so the browser's native validation catches it
+  // immediately. Unrelated to analytics, but kept here to avoid a UX
+  // regression for sites that relied on this behaviour.
+  document.querySelectorAll("#inputNewPassword1, #inputNewPassword2, #inputEmail").forEach(function(field) {
+    field.setAttribute("required", "");
+  });
 
-				let company_name            = document.querySelector("#inputCompanyName").value;
-				let street_address_2        = document.querySelector("#inputAddress2").value;
-
-        if (first_name && last_name && email_address && phone_number){
-
-          signupEvent = {
-            event: "sign_up",
-            signupData: {
-              method: "WHMCS",
-              first_name: first_name,
-              last_name: last_name,
-              email_address: email_address,
-              phone_number: phone_number,
-              //phone_country_code: phone_country_code,
-              street_address: street_address,
-              city: city,
-              state: state,
-              country: country,
-              postal_code: postal_code,
-            }
-          }
-
-          // Add to Data Layer if available
-          if(company_name){ signupEvent.signupData.company_name = company_name; }
-          if(street_address_2){ signupEvent.signupData.street_address_2 = street_address_2; }
-
-          // Submit event to Google
-          dataLayer.push(signupEvent);
-
-        }
-
-        // Submit form normally
-				register_form.submit();
-
-			}
-
-		</script>
-		';
+  form.addEventListener("submit", function() {
+    window.dataLayer = window.dataLayer || [];
+    window.dataLayer.push({
+      event: "sign_up",
+      method: "WHMCS"
+    });
+  });
+})();
+</script>
+HTML;
 	});
 
 });


### PR DESCRIPTION
Hi! These four commits were prepared by the [RareCloud.io](https://rarecloud.io) team after we adopted the module and ran a security and privacy audit on it. We're posting the improvements back upstream. Feel free to reach us at `daniel@rarecloud.io` if you'd like to discuss any of them or want changes before merging.

Each commit is self-contained and can be cherry-picked independently if you'd prefer to take only some of them.

## What's in this PR

**1. `fix: validate GTM container ID to prevent XSS in Client Area pages`**

The settings field for the GTM container ID was interpolated directly into `<script>` and `<iframe src=...>` without validation. A malicious or compromised admin could inject arbitrary JavaScript that runs on every Client Area page. New `gtm_safe_container_id()` helper enforces the canonical `GTM-XXXXXXX` format. Practical exploitability is low (admin compromise required) but the fix is small and worth having.

**2. `fix(privacy): remove PII from sign_up dataLayer event`**

The previous sign_up hook captured every visible field on the registration form (name, email, phone, full address, company) and pushed them to the dataLayer in clear text. This conflicts with [Google Analytics' Terms of Service](https://marketingplatform.google.com/about/analytics/terms/us/) (Section 7 prohibits sending PII) and the GDPR data minimisation principle (Art. 5(1)(c)). Sites using Google Ads Enhanced Conversions also need PII to be SHA-256 hashed before transfer, which the hook didn't do.

The new hook keeps `sign_up` firing on form submission but with a minimal payload (`event` + `method` only). Sites that need user-level conversion attribution can configure Google Ads Enhanced Conversions in the GTM UI, which performs the required hashing.

The hook also moves from a brittle `preventDefault() + form.submit()` click hijack to a normal `submit` event listener, restoring WHMCS' client-side form validation.

**3. `feat: optional Google Consent Mode v2 default-denied bootstrap`**

New module setting `gtm-enable-consent-mode`, default `no` (so existing installations are not affected by this upgrade). When enabled, the module injects a Consent Mode v2 default-denied bootstrap before the GTM loader, so every Google tag GTM ships sees the correct consent state from the first dataLayer event.

Required for any installation serving EU/EEA/UK visitors that loads Google tags. The site's cookie banner (or external CMP) remains responsible for calling `gtag('consent', 'update', { ... })` on accept; the module only sets the default.

**4. `docs: add CONTRIBUTORS.md crediting maintainer and contributors`**

Adds a short `CONTRIBUTORS.md` listing Websavers as the maintainer (with link), reaffirming that PRs are welcome, and giving future contributors a place to be credited in the same format.

## Notes

- All four commits maintain backward compatibility. No existing installation changes behavior after upgrading unless the admin explicitly opts in to the new Consent Mode v2 setting.
- Tested against PHP 8.1+ and WHMCS 8.x (matching the `MINIMUM REQUIREMENTS` in the README).
- Each commit's footer includes a short `https://rarecloud.io` reference.

Thanks for maintaining this module, it's the cleanest open source GTM integration for WHMCS we found, which is why we adopted it. Happy to iterate on any of these if you'd like changes before merging.
